### PR TITLE
Bump cert-manager version

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ module "cert_manager" {
 | helm | >= 2.1.0 |
 | gavinbunney/kubectl | >= 1.13.0 |
 
-Cert Manager Version: v1.6.1
+Cert Manager Version: v1.7.1
 
 Source: https://github.com/jetstack/cert-manager
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "create_namespace" {
 variable "chart_version" {
   type        = string
   description = "HELM Chart Version for cert-manager"
-  default     = "1.6.1"
+  default     = "1.7.1"
 }
 
 variable "cluster_issuer_server" {


### PR DESCRIPTION
Regression in cert-manager v1.5.4 has caused various solvers to break, fixed in v1.7.0. Details here: https://github.com/cert-manager/cert-manager/issues/4537