### PR TITLE
switch to more maintained alekc/kubectl, see https://github.com/gavin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ provider "kubernetes" {
 terraform {
   required_providers {
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.13.0"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.2"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -165,7 +165,7 @@ module "cert_manager" {
 | terraform | >= 1.0.0  |
 | kubernetes | >= 2.0.1  |
 | helm | >= 2.5.0  |
-| gavinbunney/kubectl | >= 1.13.0 |
+| alekc/kubectl | >= 2.0.2 |
 
 Cert Manager Version: v1.11.0
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.13.0"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
gavinbunney/kubectl seems to be no longer maintained:
for example I've stumbled upon serious issue in Kubernetes 1.27,
With the provider randomly deletes objects from the state,
See Issue: https://github.com/gavinbunney/terraform-provider-kubectl/issues/270

alekc/kubectl
https://registry.terraform.io/providers/alekc/kubectl/2.0.2

solves this issue, and keeping to maintain (currently) the provider
