### PR TITLE
Use type for variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -50,13 +50,14 @@ variable "cluster_issuer_yaml" {
 }
 
 variable "additional_set" {
+  type        = list(any)
   description = "Additional sets to Helm"
   default     = []
 }
 
 variable "solvers" {
   description = "List of Cert manager solvers. For a complex example please look at the Readme"
-  type        = any
+  type        = list(any)
   default = [{
     http01 = {
       ingress = {


### PR DESCRIPTION
When working with Terragrunt we encountered an issue with variables that have no type set and are being used in a for-each loop. 

See here for the error:

│ Error: Invalid dynamic for_each value
│ 
│   on main.tf line 27, in resource "helm_release" "cert_manager":
│   27:     for_each = var.additional_set
│     ├────────────────
│     │ var.additional_set is "{\"serviceAccount\":{\"name\":\"serviceAccount.annotations.eks\\\\.amazonaws\\\\.com/role-arn\",\"value\":\"arn:aws:iam::XXXXXXX:role/some-role\"}}"
│ 
│ Cannot use a string value in for_each. An iterable collection is required.

