### PR TITLE
Add `Certificate` resource labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ module "cert_manager" {
 | Name                  | Description                                                                           | Type         | Default                                                         |  Required  |
 |-----------------------|---------------------------------------------------------------------------------------|--------------|-----------------------------------------------------------------|:----------:|
 | namespace             | certificate resource namespace                                                        | string       | uses var.namespace_name of this module                          |     no     |
+| labels                | certificate resource labels                                                           | map(string)  | {}                                                              |     no     |
 | secret_name           | certificate secret name. Note: for AKS/AGIC ensure cert and secret have the same name | string       | ${Certificate Name}-tls                                         |     no     |
 | secret_annotations    | certificate secret annotations                                                        | map(string)  | {}                                                              |     no     |
 | secret_labels         | certificate secret labels                                                             | map(string)  | {}                                                              |     no     |

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ module "certificates" {
   name                  = each.key
   namespace             = try(each.value.namespace, var.namespace_name)
   annotations           = try(each.value.annotations, {})
+  labels                = try(each.value.labels, {})
   secret_name           = try(each.value.secret_name, "${each.key}-tls")
   secret_annotations    = try(each.value.secret_annotations, {})
   secret_labels         = try(each.value.secret_labels, {})

--- a/modules/_certificate/main.tf
+++ b/modules/_certificate/main.tf
@@ -2,6 +2,7 @@ locals {
   name               = var.name
   namespace          = var.namespace
   annotations        = var.annotations
+  labels             = var.labels
   secret_name        = var.secret_name
   secret_annotations = var.secret_annotations
   secret_labels      = var.secret_labels

--- a/modules/_certificate/outputs.tf
+++ b/modules/_certificate/outputs.tf
@@ -6,6 +6,7 @@ output "map" {
       name        = var.name
       namespace   = var.namespace
       annotations = var.annotations
+      labels      = var.labels
     }
     spec = {
       secretName = var.secret_name

--- a/modules/_certificate/variables.tf
+++ b/modules/_certificate/variables.tf
@@ -15,6 +15,12 @@ variable "annotations" {
   default     = {}
 }
 
+variable "labels" {
+  type        = map(string)
+  description = "certificate labels"
+  default     = {}
+}
+
 variable "secret_name" {
   type        = string
   description = "certificate secret name"


### PR DESCRIPTION
This adds an option to specify `Certificate` resource labels as discussed #29 . This allows to use `matchLabels` solver selector.