### PR TITLE
chore: bump helm chart version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "create_namespace" {
 variable "chart_version" {
   type        = string
   description = "HELM Chart Version for cert-manager"
-  default     = "1.11.0"
+  default     = "1.17.2"
 }
 
 variable "cluster_issuer_server" {


### PR DESCRIPTION
This PR updates the Helm chart version to use the latest cert-manager release.

It fixes #31, where the Cloudflare DNS challenge is broken due to API changes.

Not 100% sure if this version bump might break things for anyone’s existing setup, so feel free to let me know if it’s safe to update the default version in the variables—or if we should handle it differently :)